### PR TITLE
fix: use env() directly for TRUSTED_PROXIES in bootstrap

### DIFF
--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -11,7 +11,7 @@ return Application::configure(basePath: dirname(__DIR__))
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware): void {
-        $trustedProxies = config('proxy.trusted_proxies');
+        $trustedProxies = env('TRUSTED_PROXIES');
 
         if ($trustedProxies) {
             $middleware->trustProxies(at: $trustedProxies);


### PR DESCRIPTION
## Problem
The application crashes with a fatal error when deployed:
```
Fatal error: Uncaught ReflectionException: Class "config" does not exist
```

## Root Cause
In `bootstrap/app.php`, we were calling `config('proxy.trusted_proxies')` during middleware configuration. However, the config system isn't available yet at this point in the bootstrap process.

## Solution
Use `env('TRUSTED_PROXIES')` directly instead of going through the config system. This is appropriate since:
- The env helper is available during bootstrap
- This is a simple passthrough value (no transformation needed)
- The config file still serves as documentation

## Testing
- Tested locally with `TRUSTED_PROXIES=*`
- Verified fix resolves production deployment error

Fixes the fatal error that prevented the application from starting when TRUSTED_PROXIES was configured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)