### PR TITLE
ci: use PERSONAL_TOKEN for Release Please and Dependabot auto-merge

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -31,4 +31,4 @@ jobs:
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.PERSONAL_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,5 +16,5 @@ jobs:
     steps:
       - uses: googleapis/release-please-action@v4
         with:
-          token: ${{ secrets.MY_RELEASE_PLEASE_TOKEN }}
+          token: ${{ secrets.PERSONAL_TOKEN }}
           release-type: php


### PR DESCRIPTION
## What This Does

Standardizes the secret name used across workflows to `PERSONAL_TOKEN` instead of the tool-specific `MY_RELEASE_PLEASE_TOKEN`.

## Changes

- Release Please workflow now uses `PERSONAL_TOKEN`
- Dependabot auto-merge workflow now uses `PERSONAL_TOKEN`
- Fixes Dependabot auto-merge permission issue (was using `GITHUB_TOKEN` which lacks permissions)

## Next Step

After merging, rename the secret in GitHub:
1. Go to Settings → Secrets → Actions
2. Delete `MY_RELEASE_PLEASE_TOKEN` (if it exists)
3. Create new secret `PERSONAL_TOKEN` with the same PAT value

🤖 Generated with [Claude Code](https://claude.com/claude-code)