### PR TITLE
perf: enable comprehensive caching for Docker builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,3 +75,5 @@ jobs:
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,12 +6,12 @@ WORKDIR /app
 # Copy composer files
 COPY composer.json composer.lock ./
 
-# Install dependencies (no cache, skip discovery since we don't have Laravel yet)
-RUN composer install \
+# Install dependencies (with cache mount for faster rebuilds)
+RUN --mount=type=cache,target=/tmp/cache \
+    COMPOSER_CACHE_DIR=/tmp/cache composer install \
     --no-dev \
     --optimize-autoloader \
     --no-interaction \
-    --no-cache \
     --prefer-dist \
     --no-scripts
 
@@ -23,8 +23,9 @@ WORKDIR /app
 # Copy package files
 COPY package*.json ./
 
-# Install dependencies
-RUN npm ci
+# Install dependencies (with cache mount for faster rebuilds)
+RUN --mount=type=cache,target=/root/.npm \
+    npm ci
 
 # Copy vendor folder from PHP builder (needed for CSS references)
 COPY --from=php-builder /app/vendor ./vendor


### PR DESCRIPTION
## Summary
- Added GitHub Actions cache for Docker layer reuse
- Added Composer cache mount in php-builder stage
- Added npm cache mount in frontend-builder stage

## Problem
Docker builds were taking a long time on every run, rebuilding dependencies from scratch even when nothing changed. This was particularly painful during rapid iteration on PRs.

## Solution
Implemented multi-layered caching strategy:

1. **GitHub Actions cache** (`cache-from`/`cache-to`): Reuses Docker layers across workflow runs
2. **Composer cache mount**: Speeds up PHP dependency installation in build stage
3. **npm cache mount**: Speeds up frontend dependency installation in build stage

All caches are used only in build stages and are discarded in the final image thanks to multi-stage builds. The final image size is unchanged.

## Expected Impact
50-70% faster builds after the initial run, with no increase in final image size.

🤖 Generated with [Claude Code](https://claude.com/claude-code)