### PR TITLE
chore: allow manual triggering of release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 permissions:
   contents: write


### PR DESCRIPTION
Add workflow_dispatch trigger to the release workflow so it can be manually triggered from the GitHub Actions UI when needed.