### PR TITLE
feat: make trusted proxies configurable via environment variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -75,6 +75,7 @@ ENV DB_CONNECTION=sqlite
 ENV DB_DATABASE=/app/storage/database.sqlite
 ENV LOG_CHANNEL=daily
 ENV LOG_LEVEL=info
+ENV TRUSTED_PROXIES=*
 
 # Use file-based drivers to reduce SQLite contention
 ENV SESSION_DRIVER=file

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace App\Providers;
 
+use Illuminate\Http\Middleware\TrustProxies;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\ServiceProvider;
 use SocialiteProviders\Authentik\Provider as AuthentikProvider;
@@ -31,5 +32,29 @@ class AppServiceProvider extends ServiceProvider
         Gate::define('viewAdmin', function ($user) {
             return $user->is_admin === true;
         });
+
+        $this->setupProxies();
+    }
+
+    private function setupProxies()
+    {
+        TrustProxies::withHeaders(config('trustedproxy.headers'));
+
+        $proxies = config('trustedproxy.proxies');
+
+        if ($proxies === '') {
+            return; // trust none
+        }
+
+        if ($proxies === '*') {
+            TrustProxies::at('*');
+
+            return;
+        }
+
+        TrustProxies::at(collect(explode(',', $proxies))
+            ->map('trim')
+            ->filter()
+            ->all());
     }
 }

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -3,7 +3,6 @@
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
-use Symfony\Component\HttpFoundation\Request;
 
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
@@ -12,14 +11,7 @@ return Application::configure(basePath: dirname(__DIR__))
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware): void {
-        $middleware->trustProxies(
-            at: '*',
-            headers: Request::HEADER_X_FORWARDED_FOR |
-                Request::HEADER_X_FORWARDED_HOST |
-                Request::HEADER_X_FORWARDED_PORT |
-                Request::HEADER_X_FORWARDED_PROTO |
-                Request::HEADER_X_FORWARDED_AWS_ELB
-        );
+        //
     })
     ->withExceptions(function (Exceptions $exceptions): void {
         //

--- a/config/trustedproxy.php
+++ b/config/trustedproxy.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Http\Request;
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Trusted Proxies
+    |--------------------------------------------------------------------------
+    |
+    | Define which proxies are trusted to pass X-Forwarded headers to this app.
+    | You may trust every proxy, none at all, or a chosen list of addresses.
+    | Use TRUSTED_PROXIES for '*', nothing, or a list of proxy addresses.
+    |
+    */
+
+    'proxies' => env('TRUSTED_PROXIES', ''),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Trusted Proxy Headers
+    |--------------------------------------------------------------------------
+    |
+    | Specify which forwarded headers should be trusted when resolving requests.
+    | Common choices include X-Forwarded-For, Host, Port, Proto, and AWS ELB.
+    | Change this bitmask if proxies send fewer or nonstandard headers too
+    |
+    */
+
+    'headers' => Request::HEADER_X_FORWARDED_FOR
+        | Request::HEADER_X_FORWARDED_HOST
+        | Request::HEADER_X_FORWARDED_PORT
+        | Request::HEADER_X_FORWARDED_PROTO
+        | Request::HEADER_X_FORWARDED_AWS_ELB,
+
+];

--- a/tests/Feature/TrustedProxiesTest.php
+++ b/tests/Feature/TrustedProxiesTest.php
@@ -1,0 +1,106 @@
+<?php
+
+use App\Providers\AppServiceProvider;
+use Illuminate\Http\Middleware\TrustProxies;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Route;
+
+beforeEach(function () {
+    Route::get('/proxy-test', function (Request $request) {
+        return response()->json([
+            'ip' => $request->ip(),
+            'secure' => $request->isSecure(),
+        ]);
+    });
+});
+
+function bootAppWithProxies(string $value): void
+{
+    // Configure proxies for this test run
+    config()->set('trustedproxy.proxies', $value);
+
+    // Reset any previous state (only needed in tests)
+    TrustProxies::at([]);
+
+    // Re-run the provider boot so setupProxies() takes effect
+    (new AppServiceProvider(app()))->boot();
+}
+
+it('does not trust proxies when config is empty', function () {
+    bootAppWithProxies('');
+
+    $response = $this
+        ->withServerVariables([
+            'REMOTE_ADDR' => '192.0.2.1', // test client IP
+        ])
+        ->get('/proxy-test', [
+            // Spoofed proxy headers – should be ignored
+            'X-Forwarded-For' => '198.51.100.10',
+            'X-Forwarded-Proto' => 'https',
+        ]);
+
+    $response->assertOk();
+    $response->assertJson([
+        'ip' => '192.0.2.1', // comes from REMOTE_ADDR, not X-Forwarded-For
+        'secure' => false,       // X-Forwarded-Proto ignored
+    ]);
+});
+
+it('trusts all proxies when config is star', function () {
+    bootAppWithProxies('*');
+
+    $response = $this
+        ->withServerVariables([
+            'REMOTE_ADDR' => '192.0.2.1', // proxy IP
+        ])
+        ->get('/proxy-test', [
+            'X-Forwarded-For' => '198.51.100.10', // real client IP
+            'X-Forwarded-Proto' => 'https',
+        ]);
+
+    $response->assertOk();
+    $response->assertJson([
+        'ip' => '198.51.100.10', // taken from X-Forwarded-For now
+        'secure' => true,            // taken from X-Forwarded-Proto
+    ]);
+});
+
+it('trusts only the configured proxies from comma separated list', function () {
+    // Only 192.0.2.1 is a trusted proxy
+    bootAppWithProxies('192.0.2.1,10.0.0.0/8');
+
+    $response = $this
+        ->withServerVariables([
+            'REMOTE_ADDR' => '192.0.2.1', // trusted proxy
+        ])
+        ->get('/proxy-test', [
+            'X-Forwarded-For' => '198.51.100.10',
+            'X-Forwarded-Proto' => 'https',
+        ]);
+
+    $response->assertOk();
+    $response->assertJson([
+        'ip' => '198.51.100.10',
+        'secure' => true,
+    ]);
+});
+
+it('ignores forwarded headers if the remote address is not a trusted proxy', function () {
+    // 203.0.113.99 is NOT in the trusted proxy list
+    bootAppWithProxies('192.0.2.1,10.0.0.0/8');
+
+    $response = $this
+        ->withServerVariables([
+            'REMOTE_ADDR' => '203.0.113.99', // untrusted proxy
+        ])
+        ->get('/proxy-test', [
+            'X-Forwarded-For' => '198.51.100.10',
+            'X-Forwarded-Proto' => 'https',
+        ]);
+
+    $response->assertOk();
+    $response->assertJson([
+        'ip' => '203.0.113.99', // stays as REMOTE_ADDR
+        'secure' => false,      // X-Forwarded-Proto ignored
+    ]);
+});


### PR DESCRIPTION
Add support for TRUSTED_PROXIES so applications can explicitly control which proxies are trusted when resolving client IP and protocol details. This change defaults the configuration to an empty value so the app is secure by design, while Docker images continue trusting all proxies by setting TRUSTED_PROXIES="*" at build time.

Introduce a dedicated config file, improved proxy setup in the AppServiceProvider, and a full test suite covering none, all, and explicitly listed proxies.

Resolves: make trusted proxy configuration configurable (#19)